### PR TITLE
add: TLS (SSL) support #13 & cleaning

### DIFF
--- a/internal/types/types.go
+++ b/internal/types/types.go
@@ -3,8 +3,11 @@ package types
 
 // Config contains the possible configuration parameters that are available in the settings.json file.
 type Config struct {
-	Port  uint `json:"port"`
-	Debug bool `json:"debug"`
+	Port  uint   `json:"port"`
+	Debug bool   `json:"debug"`
+	NoTLS bool   `json:"notls"`
+	CRT   string `json:"crt"`
+	KEY   string `json:"key"`
 }
 
 // LocationUpdate contains the location update data types as retrieved from the OsmAnd app by default

--- a/main.go
+++ b/main.go
@@ -12,9 +12,6 @@ import (
 )
 
 var (
-	// IsDebug tells if the server is running in debug mode, i.e. whether or not to provide output messages.
-	IsDebug      bool // TODO: Move exported var to main.go
-	serverPort   uint
 	settingsFile string
 )
 
@@ -48,14 +45,10 @@ func main() {
 		log.Fatal(err)
 	}
 
-	serverPort = configFile.Port
-	IsDebug = configFile.Debug
-
 	db, err := database.OpenDB("./database", "locations.db")
 	if err != nil {
 		log.Fatal(err)
 	}
 
-	server.SetEnvironment(IsDebug)
-	defer server.Listen(serverPort, db)
+	defer server.Listen(configFile, db)
 }

--- a/settings.json
+++ b/settings.json
@@ -1,1 +1,1 @@
-{"port":8080,"debug":false}
+{"port":8080,"debug":true,"notls":false,"crt":"server.crt","key":"server.key"}


### PR DESCRIPTION
inside  [golang-tls](https://github.com/denji/golang-tls), they have used a custom `CipherSuites`  which is I don't think we need it at the moment because it so specific.

```
  cfg := &tls.Config{
        MinVersion:               tls.VersionTLS12,
        CurvePreferences:         []tls.CurveID{tls.CurveP521, tls.CurveP384, tls.CurveP256},
        PreferServerCipherSuites: true,
        CipherSuites: []uint16{
            tls.TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,
            tls.TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA,
            tls.TLS_RSA_WITH_AES_256_GCM_SHA384,
            tls.TLS_RSA_WITH_AES_256_CBC_SHA,
        },
    }
```